### PR TITLE
add master token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ var config = {
 | Option           | Description
 |----------------- |-----------
 | `username`       | *Required* Your Google Keep username
-| `password`       | *Required* Your Google Keep password
+| `password`       | *Required if no masterToken* Your Google Keep password
+| `masterToken`       | *Required if no password* Your Google Keep master token, as an alternative auth flow. See [gkeepapi docs](https://gkeepapi.readthedocs.io/en/latest/#obtaining-a-master-token) and [HomeAssistant Google Home docs](https://github.com/leikoilja/ha-google-home?tab=readme-ov-file#master-token).
 | `noteId`         | *Required* The ID of the list you want to display. Open the list in browser and copy the ID from adress bar (example: '1aGdg26b2Aza6ga3aKa6gafa41e1Eag8LFVkE_klE4ap0i13HGoBmNeLp3a4')
 | `updateInterval`       | *Required* How many seconds to wait before fetching an update
 | `maxLines`       | *Required* Maximum number of lines to display

--- a/script/googlekeep.py
+++ b/script/googlekeep.py
@@ -29,11 +29,12 @@ if __name__ == '__main__':
         config_json_str = sys.argv[1]
         config_json = json.loads(config_json_str)
         cfg_username = config_json['username']
-        cfg_password = config_json['password']
+        cfg_password = config_json.get('password')
+        cfg_master_token = config_json.get('masterToken')
         cfg_note_id = config_json['noteId']
         cfg_max_lines = config_json['maxLines']
         cfg_get_unchecked = config_json.get('unchecked_only', False)
-        #to_node("debug", 'user: ' + cfg_username + ' pw len: ' + str(len(cfg_password)) + ' note id: ' + cfg_note_id)
+        #to_node("debug", 'user: ' + cfg_username + ' pw len: ' + str(len(cfg_password)) + ' mastertoken provided: ' + bool(cfg_master_token) + ' note id: ' + cfg_note_id)
     except Exception:
         to_node("debug", 'could not parse config')
 
@@ -41,7 +42,12 @@ if __name__ == '__main__':
     #to_node("debug", 'Google Keep script started')
     #to_node("debug", sys.argv)
 
-    success = keep.login(cfg_username, cfg_password)
+    if cfg_password:
+        success = keep.login(cfg_username, cfg_password)
+    elif cfg_master_token:
+        success = keep.authenticate(cfg_username, cfg_master_token)
+    else:
+        raise ValueError('could not find password or masterToken in config')
     gnote = keep.get(cfg_note_id)
     header = gnote.title
 


### PR DESCRIPTION
I couldn't get the username/password flow working, but using a master token has worked for the past few days.

This adds master token-based auth, using `authenticate` flow from `gkeepapi`.